### PR TITLE
cleanup on connection failure

### DIFF
--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -55,7 +55,7 @@ sub cleanup {
     my $self = shift;
     delete $self->{cmd_cb};
     delete $self->{sock};
-    $self->{on_error}->(@_);
+    $self->{on_error}->(@_) if $self->{on_error};
 }
 
 sub connect {
@@ -72,7 +72,9 @@ sub connect {
     $self->{sock} = tcp_connect $self->{host}, $self->{port}, sub {
         my $fh = shift
             or do {
-              $cv->croak("Can't connect Redis server: $!");
+              my $err = "Can't connect Redis server: $!";
+              $self->cleanup($err);
+              $cv->croak($err);
               return
             };
 


### PR DESCRIPTION
I've noticed some issues that are caused by shutting down or restarting my redis server.

If I run a command and it fails due to a broken connection it eventually starts to hang on new commands. On the next immediate command tcp_connect fails due to the unset $fh variable. But anything after does nothing. I think this is because $self->{sock} and $self->{run_cb} are still set after the failed connection, so it doesn't attempt to connect again.

Running $self->cleanup in the connection failure block seems to fix this issue, with the added bonus of getting $self->{on_error} called when a connection fails.
