### PR TITLE
Fix for mem leak (issue #6), and minor spelling correction

### DIFF
--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -295,6 +295,7 @@ sub anyevent_read_type {
                 if($size < 0 || @lines == $size) {
                     warn "Got $size values" if DEBUG;
                     $cb->($size < 0 ? undef : \@lines);
+                    undef $reader;
                     return 1;
                 }
 
@@ -451,7 +452,7 @@ Lee Aylward
 
 Joshua Barratt
 
-Jeremy Zawodn
+Jeremy Zawodny
 
 Leon Brocard
 


### PR DESCRIPTION
As discussed here:

http://github.com/miyagawa/AnyEvent-Redis/issues#issue/6

I tested this change and it fixes my example that previously leaked.
