### PR TITLE
New multi semantics, and various cleanups

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,6 @@ name 'AnyEvent-Redis';
 all_from 'lib/AnyEvent/Redis.pm';
 readme_from 'lib/AnyEvent/Redis.pm';
 requires 'AnyEvent';
-requires 'Try::Tiny';
 build_requires 'Test::More';
 test_requires 'Test::TCP',  1.03;
 author_tests('xt');

--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -124,13 +124,13 @@ sub connect {
             $hd->push_write($send);
 
             # Are we already subscribed to anything?
-            if($self->{sub} && %{$self->{sub}}) {
+            if ($self->{sub} && %{$self->{sub}}) {
 
-              croak "Use of non-pubsub command during pubsub session may result in unexpected behaviour"
-                unless $command =~ /^p?(?:un)?subscribe$/i;
+                croak "Use of non-pubsub command during pubsub session may result in unexpected behaviour"
+                  unless $command =~ /^p?(?:un)?subscribe$/i;
 
-              # Remember subscriptions
-              $self->{sub}->{$_} ||= [$cv, $cb] for @_;
+                # Remember subscriptions
+                $self->{sub}->{$_} ||= [$cv, $cb] for @_;
 
             } elsif ($command !~ /^p?subscribe$/i) {
 
@@ -169,37 +169,37 @@ sub connect {
                 my $res_cb; $res_cb = sub {
 
                     $hd->push_read("AnyEvent::Redis::Protocol" => sub {
-                            my($res, $err) = @_;
+                        my ($res, $err) = @_;
 
-                            if(ref $res) {
-                                my $action = lc $res->[0];
-                                warn "$action $res->[1]" if DEBUG;
+                        if (ref $res) {
+                            my $action = lc $res->[0];
+                            warn "$action $res->[1]" if DEBUG;
 
-                                if($action eq 'message') {
-                                    $self->{sub}->{$res->[1]}[1]->($res->[2], $res->[1]);
+                            if ($action eq 'message') {
+                                $self->{sub}->{$res->[1]}[1]->($res->[2], $res->[1]);
 
-                                } elsif($action eq 'pmessage') {
-                                    $self->{sub}->{$res->[1]}[1]->($res->[3], $res->[2], $res->[1]);
+                            } elsif ($action eq 'pmessage') {
+                                $self->{sub}->{$res->[1]}[1]->($res->[3], $res->[2], $res->[1]);
 
-                                } elsif($action eq 'subscribe' || $action eq 'psubscribe') {
-                                    $self->{sub_count} = $res->[2];
+                            } elsif ($action eq 'subscribe' || $action eq 'psubscribe') {
+                                $self->{sub_count} = $res->[2];
 
-                                } elsif($action eq 'unsubscribe' || $action eq 'punsubscribe') {
-                                    $self->{sub_count} = $res->[2];
-                                    $self->{sub}->{$res->[1]}[0]->send;
-                                    delete $self->{sub}->{$res->[1]};
-                                    $self->all_cv->end;
+                            } elsif ($action eq 'unsubscribe' || $action eq 'punsubscribe') {
+                                $self->{sub_count} = $res->[2];
+                                $self->{sub}->{$res->[1]}[0]->send;
+                                delete $self->{sub}->{$res->[1]};
+                                $self->all_cv->end;
 
-                                } else {
-                                    warn "Unknown pubsub action: $action";
-                                }
+                            } else {
+                                warn "Unknown pubsub action: $action";
                             }
+                        }
 
-                            if($self->{sub_count} || %{$self->{sub}}) {
-                                # Carry on reading while we are subscribed
-                                $res_cb->();
-                            }
-                        });
+                        if ($self->{sub_count} || %{$self->{sub}}) {
+                            # Carry on reading while we are subscribed
+                            $res_cb->();
+                        }
+                    });
                 };
 
                 $res_cb->();

--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -162,7 +162,6 @@ sub connect {
                     if ($err || ref($res) ne 'ARRAY') {
                         $_->croak($res, 1) for $cv, @$mcvs;
                     } else {
-                        $DB::single++;
                         for my $i (0 .. $#$mcvs) {
                             my $r = $res->[$i];
                             ref($r) && UNIVERSAL::isa($r, 'AnyEvent::Redis::Error')

--- a/lib/AnyEvent/Redis/Error.pm
+++ b/lib/AnyEvent/Redis/Error.pm
@@ -1,0 +1,10 @@
+package AnyEvent::Redis::Error;
+
+use strict;
+use warnings;
+
+sub message {
+    ${ $_[0] }
+}
+
+1;


### PR DESCRIPTION
The core of this change has three parts: (1) Treating errors in bulk replies as special reply elements (AnyEvent::Redis::Error); (2) collecting CVs while reading the QUEUEd markers inside a transaction, and (3) matching these CVs to elements of the EXEC bulk reply.  This means that each transaction command gets its own response.  The EXEC still gets the full response, for compatibility.

There's a lot more in here, though, and I think it's all worthwhile.  For review purposes, try "diff -w" so you can temporarily ignore the whitespace changes which only make the code consistent in style.
