### PR TITLE
re-queue commands and reconnect on read/write errors

### DIFF
--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -220,8 +220,6 @@ sub connect {
                         $res = [split / /, $res];
                     }
 
-                    # remove current command from list of running commands
-
                     $self->all_cv->end;
                     $err ? $cv->croak($res) : $cv->send($res);
                 });

--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -154,6 +154,9 @@ sub connect {
 
             warn $send if DEBUG;
 
+            my $retry = [$cv, $command, @args];
+            push @{$self->{running_cmds}}, $retry;
+
             $hd->push_write($send);
 
             if ($self->{sub} && %{$self->{sub}}) {
@@ -198,8 +201,6 @@ sub connect {
                 });
 
             } elsif ($command !~ /^p?subscribe\z/) {
-                my $retry = [$cv, $command, @args];
-                push @{$self->{running_cmds}}, $retry;
 
                 $hd->push_read("AnyEvent::Redis::Protocol" => sub {
                     my ($res, $err) = @_;

--- a/t/reconnect.t
+++ b/t/reconnect.t
@@ -3,20 +3,19 @@ use Test::More;
 use t::Redis;
 
 test_redis {
-    my ($r, $port) = @_;
+    my ($r, $port, $server) = @_;
 
-    # make a new redis object using wrong port
-    my $redis = AnyEvent::Redis->new(host => "127.0.0.1", port => Test::TCP::empty_port());
+    my $info = $r->info->recv;
+    ok $info->{redis_version}, "initial command";
 
-    # should fail
-    eval { $redis->info->recv; };
+    $server->stop;
+    $server->start;
 
-    # fix the port and try again
-    $redis->{port} = $port;
+    my $cv = AE::cv;
 
-    my $info = $redis->info->recv;
+    $info = $r->info->recv;
+    ok $info->{redis_version}, "reconnect command";
 
-    ok $info->{redis_version}, "got response after reconnect";
 };
 
 done_testing;

--- a/t/reconnect.t
+++ b/t/reconnect.t
@@ -13,9 +13,23 @@ test_redis {
 
     my $cv = AE::cv;
 
-    $info = $r->info->recv;
-    ok $info->{redis_version}, "reconnect command";
+    $cv->begin;
 
+    $r->info(sub {
+      my $info = shift;
+      ok $info->{redis_version}, "reconnect command";
+      $cv->end;
+    });
+
+    $cv->begin;
+
+    $r->info(sub {
+      my $info = shift;
+      ok $info->{redis_version}, "reconnect command";
+      $cv->end;
+    });
+
+    $cv->recv;
 };
 
 done_testing;


### PR DESCRIPTION
This fixes problems caused by a redis-server restart. Previously, a server restart would cause the first subsequent command to silently fail. The on_error handler is not invoked until the first read attempt is made. So now the on_error handler checks for commands that were waiting for a read and re-queues them and reconnects.
