### PR TITLE
Feature/support redis server2.6

### DIFF
--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -290,7 +290,7 @@ sub connect {
                     $self->_expect($cv);
 
                     if ($command eq 'info') {
-                        $res = { map { split /:/, $_, 2 } split /\r\n/, $res };
+                        $res = { map { split /:/, $_, 2 } grep !/^#/, split /\r\n/, $res };
                     } elsif ($command eq 'keys' && !ref $res) {
                         # Older versions of Redis (1.2) need this
                         $res = [split / /, $res];

--- a/t/redis.conf.base
+++ b/t/redis.conf.base
@@ -112,5 +112,5 @@ databases 16
 # Glue small output buffers together in order to send small replies in a
 # single TCP packet. Uses a bit more CPU but most of the times it is a win
 # in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
+## glueoutputbuf yes
 


### PR DESCRIPTION
`t/client.t` fails with redis-server 2.6.x by following reasons
- `glueoutputbuf yes` config is no longer supported on 2.6
- Output format of `info` command changed, and AnyEvent::Redis parser wont recognize it.

This patch fixes it. I also tested this patch works with redis-server 2.4.x
