### PR TITLE
clean-up also connect_queue AE::cv-s

### DIFF
--- a/lib/AnyEvent/Redis.pm
+++ b/lib/AnyEvent/Redis.pm
@@ -63,7 +63,8 @@ sub cleanup {
     $self->{on_error}->(@_) if $self->{on_error};
     $self->{on_cleanup}->(@_) if $self->{on_cleanup};
     for (splice(@{$self->{pending_cvs}}),
-         splice(@{$self->{multi_cvs} || []}))
+         splice(@{$self->{multi_cvs} || []}),
+         (map {$_->[0]} splice(@{$self->{connect_queue}})))
     {
         eval { $_->croak(@_) };
         warn "Exception in cleanup callback (ignored): $@" if $@;


### PR DESCRIPTION
Hi,

`cleanup()` may leave the `AE::cv` objects without `recv()` in `connect_queue` array resulting in hanging of the async code. Here is a simple code that will never finish:

````
#!/usr/bin/perl

use AnyEvent::Redis;
 
my $redis = AnyEvent::Redis->new(
    port => 9999,   # unallocated port
    on_error => sub { warn @_ },
    on_cleanup => sub { warn "Connection closed: @_" },
);
 
my $cv1 = $redis->get( 'foo1' );
my $cv2 = $redis->get( 'foo2' );
$cv2->recv;
````
will output:
````
Can't connect Redis server: Connection refused at ./connect_queue_bug.pl line 7.
Connection closed: Can't connect Redis server: Connection refused at ./connect_queue_bug.pl line 8.
````
and never finish.

With this patch:
````
Can't connect Redis server: Connection refused at ./connect_queue_bug.pl line 7.
Connection closed: Can't connect Redis server: Connection refused at ./connect_queue_bug.pl line 8.
Can't connect Redis server: Connection refused at ./connect_queue_bug.pl line 14.
````
and terminate normally.

Best regards
Jozef
